### PR TITLE
Add protected router with configure block

### DIFF
--- a/Sources/HotSoda/AbilityProtectedMiddleware.swift
+++ b/Sources/HotSoda/AbilityProtectedMiddleware.swift
@@ -73,6 +73,10 @@ public extension Router {
     func protected<T>(_ subject: T.Type, for types: [AbilityType]) -> Router where T: AbilityProtected, T: Model, T: Parameter, T.ResolvedParameter == Future<T> {
         return grouped(AbilityProtectedMiddleware<T>(for: types))
     }
+
+    func protect<T>(_ subject: T.Type, for types: [AbilityType], configure: (Router) -> Void) where T: AbilityProtected, T: Model, T: Parameter, T.ResolvedParameter == Future<T> {
+        group(AbilityProtectedMiddleware<T>(for: types), configure: configure)
+    }
 }
 
 private extension Request {


### PR DESCRIPTION
Now we can protect routes with block
```swift
router.protect(User.self, for: [.create]) { router in
    router.post("users", use: UserController().store)
}
```